### PR TITLE
Use CvmfsManager for remounting

### DIFF
--- a/plugins/aufs_cvmfs/aufs/aufs.go
+++ b/plugins/aufs_cvmfs/aufs/aufs.go
@@ -449,7 +449,7 @@ func (a *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 		orig := a.getDiffPath(id)
 
 		fmt.Printf("Orig diffpath: %s\n", orig)
-		newLayer, err := util.UploadNewLayer(orig)
+		newLayer, err := util.UploadNewLayer(orig, a.cvmfsManager)
 		if err != nil {
 			fmt.Printf("error on UploadNewLayer(): %s", err.Error())
 			return nil, err

--- a/plugins/overlay2_cvmfs/overlay2/overlay.go
+++ b/plugins/overlay2_cvmfs/overlay2/overlay.go
@@ -739,7 +739,7 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 
 	if isThin {
 		thin := util.ReadThinFile(path.Join(parent_thin_path, "diff", ".thin"))
-		newLayer, _ := util.UploadNewLayer(diffPath)
+		newLayer, _ := util.UploadNewLayer(diffPath, d.cvmfsManager)
 		thin.AddLayer(newLayer)
 		newThinLayer, _ = util.WriteThinFile(thin)
 		exportPath = newThinLayer

--- a/plugins/util/cvmfs.go
+++ b/plugins/util/cvmfs.go
@@ -134,6 +134,7 @@ type ICvmfsManager interface {
 	Put(repo string) error
 	PutLayers(layers ...ThinImageLayer) error
 	PutAll() error
+	Remount(repo string) error
 }
 
 type cvmfsManager struct {
@@ -168,7 +169,7 @@ func (cm *cvmfsManager) mount(repo string) error {
 		fmt.Printf("%s\n", out)
 		return err
 	} else {
-		fmt.Println("default repo mounted successfully!")
+		fmt.Println("Repo mounted successfully!")
 	}
 
 	return nil
@@ -262,6 +263,24 @@ func (cm *cvmfsManager) GetLayers(layers ...ThinImageLayer) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (cm *cvmfsManager) Remount(repo string) error {
+	if _, ok := cm.ctr[repo]; !ok {
+		return nil
+	}
+
+	cmd := "cvmfs_talk"
+	args := []string{"-i", repo, "remount", "sync"}
+
+	out, err := exec.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		fmt.Println(string(out))
+		fmt.Println(err)
+		return err
+	}
+
 	return nil
 }
 

--- a/plugins/util/publish.go
+++ b/plugins/util/publish.go
@@ -128,21 +128,7 @@ func upload(src, h string) error {
 	return nil
 }
 
-func remountCvmfs() error {
-	cmd := "cvmfs_talk"
-	args := []string{"-i", minioConfig.CvmfsRepo, "remount", "sync"}
-
-	out, err := exec.Command(cmd, args...).CombinedOutput()
-	if err != nil {
-		fmt.Println(string(out))
-		fmt.Println(err)
-		return err
-	} else {
-		return nil
-	}
-}
-
-func UploadNewLayer(orig string) (layer ThinImageLayer, err error) {
+func UploadNewLayer(orig string, cvmfsManager ICvmfsManager) (layer ThinImageLayer, err error) {
 	tarFileName, err := tar(orig)
 
 	if err != nil {
@@ -161,7 +147,7 @@ func UploadNewLayer(orig string) (layer ThinImageLayer, err error) {
 		return layer, err
 	}
 
-	if err := remountCvmfs(); err != nil {
+	if err := cvmfsManager.Remount(minioConfig.CvmfsRepo); err != nil {
 		fmt.Printf("Failed to remount cvmfs repo: %s\n", err.Error())
 		return layer, err
 	}

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -71,7 +71,7 @@ func (cm CvmfsManager) StartTransaction() error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Println("ERROR: failed to open transaction!")
 		fmt.Println(err)
-		fmt.Println(out)
+		fmt.Println(string(out))
 		return err
 	}
 	fmt.Println("Started transaction...")


### PR DESCRIPTION
Until now the UploadNewLayer() helper function was doing remounting of the CVMFS repository directly.
If a repository isn't mounted, it shouldn't be remounted.
CvmfsManager is only piece of code that keeps track of the mounted CVMFS repositories so remounting is also delegated to it.