### PR TITLE
Improve publisher status API

### DIFF
--- a/plugins/util/cvmfs.go
+++ b/plugins/util/cvmfs.go
@@ -289,7 +289,7 @@ func (cm *cvmfsManager) Remount(repo string) error {
 	if cm.ctr[repo] == 0 {
 		return nil
 	}
-
+	l
 	cmd := "cvmfs_talk"
 	args := []string{"-i", repo, "remount", "sync"}
 

--- a/plugins/util/publish.go
+++ b/plugins/util/publish.go
@@ -149,12 +149,25 @@ func waitForPublishing(hash string) {
 		buf, err := ioutil.ReadAll(resp.Body)
 		body := string(buf)
 
+		if resp.StatusCode != 200 {
+			fmt.Println("Request failed, abort.")
+			fmt.Println(body)
+			return
+		}
+
 		if body == "publishing" {
+			fmt.Println("Still publishing...")
 			time.Sleep(1 * time.Second)
 		} else if body == "done" {
+			fmt.Println("Publishing done!")
 			break
 		} else if body == "unknown" {
 			fmt.Println("Unknown publish status, abort.")
+			fmt.Println("EXPERIMENTAL: just try to wait.")
+			time.Sleep(1 * time.Second)
+		} else {
+			fmt.Println("Unknown reponse, abort.")
+			fmt.Println(body)
 			break
 		}
 

--- a/publisher/cvmfs.go
+++ b/publisher/cvmfs.go
@@ -56,7 +56,6 @@ func (cm CvmfsManager) PublishTransaction() error {
 		return err
 	} else {
 		fmt.Println("Published transaction!")
-		fmt.Println(string(out))
 		return nil
 	}
 }
@@ -75,10 +74,14 @@ func (cm CvmfsManager) AbortTransaction() error {
 
 func (cm CvmfsManager) LookupLayer(hash string) bool {
 	dst := path.Join("/cvmfs", cm.CvmfsRepo, "layers", hash)
+	fmt.Printf("Layer lookup path: %s\n", dst)
 
 	if _, err := os.Stat(dst); err == nil {
 		return true
+	} else if os.IsNotExist(err) {
+		return false
 	} else {
+		fmt.Println(err)
 		return false
 	}
 }

--- a/publisher/handlers.go
+++ b/publisher/handlers.go
@@ -7,10 +7,10 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func webhookHandler(w http.ResponseWriter, r *http.Request) {
+func publishRequestHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Got a publish request!")
 
-	var obj Object
+	var obj PublishingObject
 	var err error
 	if obj, err = decodePayload(r); err != nil {
 		fmt.Println("Failed to parse request.")
@@ -20,19 +20,19 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("Bucket:\t%s\n", obj.Bucket)
 	fmt.Printf("Key:\t%s\n", obj.Key)
 
-	publisherChannel <- obj
+	publishRequestChan <- obj
 	w.WriteHeader(200)
 }
 
-func statusHandler(w http.ResponseWriter, r *http.Request) {
+func statusRequestHandler(w http.ResponseWriter, r *http.Request) {
 	var obj StatusRequest
 
 	vars := mux.Vars(r)
 
 	obj.Key = string(vars["id"])
 
-	statusChannel <- obj
-	obj = <-statusChannel
+	statusRequestChan <- obj
+	obj = <-statusResponseChan
 
 	if obj.Status == "done" {
 		w.Write([]byte("done"))

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -9,9 +9,12 @@ import "github.com/gorilla/mux"
 var cm CvmfsManager
 
 var publisherConfig PublisherConfig
-var publisherChannel = make(chan Object, 1)
-var controlChannel = make(chan string, 1)
-var statusChannel = make(chan StatusRequest, 1)
+
+var publishRequestChan = make(chan PublishingObject)
+var statusRequestChan = make(chan StatusRequest)
+var statusResponseChan = make(chan StatusRequest)
+var backendChan = make(chan PublishingObject, 32)
+var controlChan = make(chan string)
 
 func main() {
 	if len(os.Args) < 2 {
@@ -28,12 +31,12 @@ func main() {
 
 	cm = CvmfsManager{CvmfsRepo: publisherConfig.CvmfsRepo}
 
-	go publishWorker()
-	go statusWorker()
+	go frontendWorker()
+	go backendWorker()
 
 	m := mux.NewRouter()
-	m.HandleFunc("/", webhookHandler)
-	m.HandleFunc("/status/{id}", statusHandler)
+	m.HandleFunc("/", publishRequestHandler)
+	m.HandleFunc("/status/{id}", statusRequestHandler)
 	http.Handle("/", m)
 	http.ListenAndServe(":3000", nil)
 }

--- a/publisher/sync.go
+++ b/publisher/sync.go
@@ -3,18 +3,17 @@ package main
 import (
 	"fmt"
 	"path"
+	"sort"
 )
 
-func publishWorker() {
+func backendWorker() {
 	for {
-		obj := <-publisherChannel
-		controlChannel <- obj.Key
-		fmt.Println("Publishing started!")
+		obj := <-backendChan
 
 		if err := cm.StartTransaction(); err != nil {
 			fmt.Println(err)
 			cm.AbortTransaction()
-			controlChannel <- ""
+			controlChan <- obj.Key
 			continue
 		}
 
@@ -22,37 +21,49 @@ func publishWorker() {
 		if err := cm.ImportTarball(filepath, obj.Key); err != nil {
 			fmt.Println(err)
 			cm.AbortTransaction()
-			controlChannel <- ""
+			controlChan <- obj.Key
 			continue
 		}
 
 		if err := cm.PublishTransaction(); err != nil {
 			fmt.Println(err)
 			cm.AbortTransaction()
-			controlChannel <- ""
+			controlChan <- obj.Key
 			continue
 		}
-		controlChannel <- ""
-		fmt.Println("Publishing finished!")
+		controlChan <- obj.Key
 	}
 }
 
-func statusWorker() {
-	var m string
+func frontendWorker() {
+	// var m string
+	var buffer []string
 
 	for {
 		select {
-		case key := <-controlChannel:
-			m = key
-		case req := <-statusChannel:
-			if m == req.Key {
+		case req := <-publishRequestChan:
+			buffer = append(buffer, req.Key)
+			sort.Strings(buffer)
+			fmt.Printf("Got new publishing request: %v\n", req.Key)
+			backendChan <- req
+		case key := <-controlChan:
+			fmt.Printf("Got update, layer %s published!", key)
+			if i := sort.SearchStrings(buffer, key); i < len(buffer) {
+				buffer = append(buffer[:i], buffer[i+1:]...)
+			}
+		case req := <-statusRequestChan:
+			pos := sort.SearchStrings(buffer, req.Key)
+			if pos < len(buffer) && buffer[pos] == req.Key {
 				req.Status = "publishing"
 			} else if cm.LookupLayer(req.Key) {
+				fmt.Printf("Found published layer %v\n", req.Key)
 				req.Status = "done"
 			} else {
+				fmt.Printf("layer %v lookup failed\n", req.Key)
 				req.Status = "unknown"
 			}
-			statusChannel <- req
+
+			statusResponseChan <- req
 		}
 	}
 

--- a/publisher/types.go
+++ b/publisher/types.go
@@ -16,15 +16,15 @@ type WebhookPayload struct {
 	Records   []StoredObjectRecord
 }
 
-type Object struct {
+type PublishingObject struct {
 	Bucket string
 	Key    string
 }
 
-func (p *WebhookPayload) Object() Object {
+func (p *WebhookPayload) Object() PublishingObject {
 	s3 := p.Records[0].S3
 
-	return Object{
+	return PublishingObject{
 		Bucket: s3.Bucket.Name,
 		Key:    s3.Object.Key,
 	}

--- a/publisher/util.go
+++ b/publisher/util.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-func decodePayload(r *http.Request) (obj Object, err error) {
+func decodePayload(r *http.Request) (obj PublishingObject, err error) {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(r.Body)
 


### PR DESCRIPTION
Better support for concurrent publish requests. A simple FIFO buffer is added to keep track of all requests. Currently up to 32 requests can be buffered in a burst, but this is configurable by changing length of the `backendChan` channel.